### PR TITLE
Set devices to auto to enable auto identification from the system

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -246,7 +246,7 @@ if __name__ == "__main__":
         callbacks=[checkpoint_callback],
         val_check_interval=args.eval_every,
         # gpus=1, # deprecated
-        devices=[GPU_IDX],
+        devices="auto",
         accelerator="gpu",
         log_every_n_steps=args.log_every,
         max_epochs=DEFAULT_MAX_EPOCHS,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -11,9 +11,7 @@ from pytorch_lightning import Trainer, seed_everything
 import wandb
 import torch
 
-from ikflow.config import DATASET_TAG_NON_SELF_COLLIDING, GPU_IDX
-
-assert GPU_IDX >= 0
+from ikflow.config import DATASET_TAG_NON_SELF_COLLIDING
 from ikflow import config
 from ikflow.model import IkflowModelParameters
 from ikflow.ikflow_solver import IKFlowSolver

--- a/scripts/train_from_checkpoint.py
+++ b/scripts/train_from_checkpoint.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
         logger=wandb_logger,
         callbacks=[checkpoint_callback],
         val_check_interval=run_cfg["eval_every"],
-        devices=[GPU_IDX],
+        devices="auto",
         accelerator="gpu",
         log_every_n_steps=run_cfg["log_every"],
         max_epochs=DEFAULT_MAX_EPOCHS,

--- a/scripts/train_from_checkpoint.py
+++ b/scripts/train_from_checkpoint.py
@@ -4,9 +4,6 @@ from time import time
 
 
 from ikflow import config
-from ikflow.config import GPU_IDX
-
-assert GPU_IDX >= 0
 from ikflow.model import IkflowModelParameters
 from ikflow.ikflow_solver import IKFlowSolver
 from jrl.robots import get_robot


### PR DESCRIPTION
Replace GPU_IDX definitions in all train scripts. Use device="auto" to enable lightning to auto specify max count from the system