### PR TITLE
Bugfixes to train and evaluate scripts

### DIFF
--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -97,7 +97,7 @@ def calculate_runtime_stats(ik_solver: IKFlowSolver, n_solutions: int, k: int, r
     poses = ik_solver.robot.forward_kinematics_klampt(ik_solver.robot.sample_joint_angles(n_solutions * k))
     with torch.inference_mode():
         for k_i in range(k):
-            target_poses = target_poses = torch.tensor(poses[k_i * n_solutions : (k_i + 1) * n_solutions], dtype=torch.float32)
+            target_poses = torch.tensor(poses[k_i * n_solutions : (k_i + 1) * n_solutions], dtype=torch.float32)
             assert target_poses.shape == (n_solutions, 7)
             t0 = time()
             ik_solver.generate_ik_solutions(target_poses, None, refine_solutions=refine_solutions)[1]

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -11,7 +11,8 @@ from pytorch_lightning import Trainer, seed_everything
 import wandb
 import torch
 
-from ikflow.config import DATASET_TAG_NON_SELF_COLLIDING, GPU_IDX
+from ikflow.config import DATASET_TAG_NON_SELF_COLLIDING
+from jrl.config import GPU_IDX
 
 assert GPU_IDX >= 0
 from ikflow import config

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -247,7 +247,7 @@ if __name__ == "__main__":
         callbacks=[checkpoint_callback],
         val_check_interval=args.eval_every,
         # gpus=1, # deprecated
-        devices="auto",
+        devices=[GPU_IDX],
         accelerator="gpu",
         log_every_n_steps=args.log_every,
         max_epochs=DEFAULT_MAX_EPOCHS,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -246,7 +246,7 @@ if __name__ == "__main__":
         callbacks=[checkpoint_callback],
         val_check_interval=args.eval_every,
         # gpus=1, # deprecated
-        devices=[GPU_IDX],
+        devices="auto",
         accelerator="gpu",
         log_every_n_steps=args.log_every,
         max_epochs=DEFAULT_MAX_EPOCHS,

--- a/scripts/train_from_checkpoint.py
+++ b/scripts/train_from_checkpoint.py
@@ -4,7 +4,7 @@ from time import time
 
 
 from ikflow import config
-from ikflow.config import GPU_IDX
+from jrl.config import GPU_IDX
 
 assert GPU_IDX >= 0
 from ikflow.model import IkflowModelParameters

--- a/scripts/train_from_checkpoint.py
+++ b/scripts/train_from_checkpoint.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
         logger=wandb_logger,
         callbacks=[checkpoint_callback],
         val_check_interval=run_cfg["eval_every"],
-        devices=[GPU_IDX],
+        devices="auto",
         accelerator="gpu",
         log_every_n_steps=run_cfg["log_every"],
         max_epochs=DEFAULT_MAX_EPOCHS,

--- a/scripts/train_from_checkpoint.py
+++ b/scripts/train_from_checkpoint.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
         logger=wandb_logger,
         callbacks=[checkpoint_callback],
         val_check_interval=run_cfg["eval_every"],
-        devices="auto",
+        devices=[GPU_IDX],
         accelerator="gpu",
         log_every_n_steps=run_cfg["log_every"],
         max_epochs=DEFAULT_MAX_EPOCHS,


### PR DESCRIPTION
- Add minor correction to evaluate.py
- Remove GPU_IDX in train*.py. GPU_IDX was not declared previously in config.py. Set devices="auto" to allow lightning to infer the max device counts. This implies that all devices in the system will be used